### PR TITLE
Backslash

### DIFF
--- a/normalizer/modules/kippo_events.py
+++ b/normalizer/modules/kippo_events.py
@@ -23,7 +23,7 @@ class KippoEvents(BaseNormalizer):
     channels = ('kippo.sessions',)
 
     def normalize(self, data, channel, submission_timestamp, ignore_rfc1918=True):
-        o_data = json.loads(data)
+        o_data = data
 
         if ignore_rfc1918 and self.is_RFC1918_addr(o_data['peerIP']):
             return []

--- a/persistance/mnemodb.py
+++ b/persistance/mnemodb.py
@@ -18,6 +18,7 @@
 import logging
 import string
 import time
+import json
 from datetime import datetime
 
 from pymongo import MongoClient
@@ -112,7 +113,7 @@ class MnemoDB(object):
             payload = str(payload).encode('hex')
         else:
             payload = str(payload)
-
+        payload = json.loads(payload)
         timestamp = datetime.utcnow()
         entry = {'channel': channel,
                  'ident': ident,


### PR DESCRIPTION
Payload is added to hpfeeds collection with backslashes which results in the keys to be unusable as it's already has been escaped 

This change will result into the payload and session to be written without backslashes 