### PR TITLE
Resolve incorrect session protocol extraction from Cowrie Telnet Honeypot

### DIFF
--- a/normalizer/modules/cowrie_events.py
+++ b/normalizer/modules/cowrie_events.py
@@ -34,7 +34,7 @@ class CowrieEvents(BaseNormalizer):
             'source_port': o_data['peerPort'],
             'destination_port': o_data['hostPort'],
             'honeypot': 'cowrie',
-            'protocol': 'ssh',
+            'protocol': o_data['protocol'],
             'session_ssh': {'version': o_data['version']}
         }
 


### PR DESCRIPTION
If you was customized your Cowrie honeypot as Telnet Honeypot, you'll encountered problems with session object protocol extraction. You'll always get "SSH" protocol rather then other possible realized options -  telnet protocol in particular.

This pull request'll resolve this issue.